### PR TITLE
Update method signatures/calls to fix build

### DIFF
--- a/yosemite/Bananas/Bananas/AppDelegate.cs
+++ b/yosemite/Bananas/Bananas/AppDelegate.cs
@@ -7,7 +7,7 @@ namespace Bananas
 {
 	public partial class AppDelegate : NSApplicationDelegate
 	{
-		public override void FinishedLaunching (NSObject notification)
+		public override void DidFinishLaunching (NSNotification notification)
 		{
 			SharedAppDelegate.AppDelegate = new SharedAppDelegate (scnView);
 			window.DisableSnapshotRestoration ();

--- a/yosemite/Bananas/Bananas/SpriteKit Overlay UI/PostGameMenu.cs
+++ b/yosemite/Bananas/Bananas/SpriteKit Overlay UI/PostGameMenu.cs
@@ -46,7 +46,7 @@ namespace Bananas
 			bananaText = (SKLabelNode)myLabel.Copy ();
 			bananaText.Text = "Bananas";
 			bananaText.FontSize = 0.1f * menuHeight;
-			bananaText.Scale = 0.8f;
+			bananaText.SetScale(0.8f);
 			bananaLocation.X += bananaText.CalculateAccumulatedFrame ().Width * 0.5f + frameSize.Width * 0.1f;
 			bananaText.Position = new CGPoint (bananaLocation.X, -2000);
 			AddChild (bananaText);


### PR DESCRIPTION
Currently the Bananas sample doesn't build in the latest Xamarin Studio/API Levels. This update allows the code to build. Other changes are probably required to really update this sample to the current versions of the APIs, this just gets it building.