### PR TITLE
Place the views in an NSScrollView instead of NSClipView

### DIFF
--- a/NSOutlineViewAndTableView/NSOutlineViewAndTableViewExample/NSOutlineViewCode/NSOutlineViewExample.cs
+++ b/NSOutlineViewAndTableView/NSOutlineViewAndTableViewExample/NSOutlineViewCode/NSOutlineViewExample.cs
@@ -27,12 +27,11 @@ namespace NSOutlineViewAndTableViewExample
 			outlineView.Delegate = new OutlineViewDelegate ();
 			outlineView.DataSource = new OutlineViewDataSource ();
 
-			// NSOutlineView expects to be hosted inside an NSClipView and won't draw correctly otherwise  
-			NSClipView clipView = new NSClipView (frame) {
+			NSScrollView scrollView = new NSScrollView (frame) {
 				AutoresizingMask = NSViewResizingMask.HeightSizable | NSViewResizingMask.WidthSizable
 			};
-			clipView.DocumentView = outlineView;
-			return clipView;
+			scrollView.DocumentView = outlineView;
+			return scrollView;
 		}
 	}
 

--- a/NSOutlineViewAndTableView/NSOutlineViewAndTableViewExample/NSTableViewCode/NSTableViewExample.cs
+++ b/NSOutlineViewAndTableView/NSOutlineViewAndTableViewExample/NSTableViewCode/NSTableViewExample.cs
@@ -25,12 +25,11 @@ namespace NSOutlineViewAndTableViewExample
 			tableView.DataSource = new TableDataSource ();
 			tableView.Delegate = new TableDelegate ();
 
-			// NSTableView expects to be hosted inside an NSClipView and won't draw correctly otherwise  
-			NSClipView clipView = new NSClipView (frame) {
+			NSScrollView scrollView = new NSScrollView (frame) {
 				AutoresizingMask = NSViewResizingMask.HeightSizable | NSViewResizingMask.WidthSizable
 			};
-			clipView.DocumentView = tableView;
-			return clipView;
+			scrollView.DocumentView = tableView;
+			return scrollView;
 		}
 	}
 


### PR DESCRIPTION
To enable scrolling in the NSOutlineViewAndTableView demo, the views need to be placed in NSScrollView and not NSClipView