### PR TITLE
Force type cast for AppDelegate

### DIFF
--- a/NSPortExample/MessageReceiver/MessageReceiver/AppDelegate.m
+++ b/NSPortExample/MessageReceiver/MessageReceiver/AppDelegate.m
@@ -20,7 +20,7 @@ static CFDataRef Callback(CFMessagePortRef port,
 {
     
     NSString* newStr = [NSString stringWithUTF8String:[(__bridge NSData*)data bytes]];
-    [[NSApp delegate] addItem:newStr];
+    [(AppDelegate*)[NSApp delegate] addItem:newStr];
     return nil;
 }
 


### PR DESCRIPTION
It was necessary to explicitly inform the type of the AppDelegate class in order to the "addItem:" method to be recognized by the compiler.