### PR TITLE
Fixes line width not animating issue. 

### DIFF
--- a/CoreAnimationBook/CustomizeAnimation/MyView.cs
+++ b/CoreAnimationBook/CustomizeAnimation/MyView.cs
@@ -54,7 +54,7 @@ namespace CustomizeAnimation
 		
 		public void setLineWidth(float value)
 		{
-			SetValueForKeyPath((NSNumber) value,(NSString)"drawnLineWidth");
+			SetValueForKey((NSNumber) value,(NSString)"drawnLineWidth");
 		}
 		
 		[Export("drawnLineWidth")]


### PR DESCRIPTION
Fixes issue with line width not animating in CustomizeAnimation sample. Issue was brought up in forums [1], for which bug report 60373 [2] was filed. 


[1] https://forums.xamarin.com/discussion/105564/animations-example-is-not-working#latest
[2] https://bugzilla.xamarin.com/show_bug.cgi?id=60373