### PR TITLE
Samplefix maccopypaste

### DIFF
--- a/MacCopyPaste/MacCopyPaste/Classes/ImageDocument.cs
+++ b/MacCopyPaste/MacCopyPaste/Classes/ImageDocument.cs
@@ -95,11 +95,7 @@ namespace MacCopyPaste
 					ImageInfo info = (ImageInfo)objectsToPaste[0];
 
 				}
-
-
-
 			}
-
 		}
 		#endregion
 	}

--- a/MacCopyPaste/MacCopyPaste/Classes/ImageDocument.cs
+++ b/MacCopyPaste/MacCopyPaste/Classes/ImageDocument.cs
@@ -93,7 +93,6 @@ namespace MacCopyPaste
 				if (objectsToPaste.Length > 0)
 				{
 					ImageInfo info = (ImageInfo)objectsToPaste[0];
-
 				}
 			}
 		}

--- a/MacCopyPaste/MacCopyPaste/Classes/ImageDocument.cs
+++ b/MacCopyPaste/MacCopyPaste/Classes/ImageDocument.cs
@@ -90,7 +90,10 @@ namespace MacCopyPaste
 			if (ok) {
 				// Read the image off of the pasteboard
 				NSObject [] objectsToPaste = pasteboard.ReadObjectsForClasses (classArray2, null);
-				ImageInfo info = (ImageInfo)objectsToPaste[0];
+                if (objectsToPaste.Length > 0)
+                {
+                    ImageInfo info = (ImageInfo)objectsToPaste[0];
+                }
 
 
 			}

--- a/MacCopyPaste/MacCopyPaste/Classes/ImageDocument.cs
+++ b/MacCopyPaste/MacCopyPaste/Classes/ImageDocument.cs
@@ -90,10 +90,10 @@ namespace MacCopyPaste
 			if (ok) {
 				// Read the image off of the pasteboard
 				NSObject [] objectsToPaste = pasteboard.ReadObjectsForClasses (classArray2, null);
-                if (objectsToPaste.Length > 0)
-                {
-                    ImageInfo info = (ImageInfo)objectsToPaste[0];
-                }
+                	if (objectsToPaste.Length > 0)
+                	{
+                    		ImageInfo info = (ImageInfo)objectsToPaste[0];
+                	}
 
 
 			}

--- a/MacCopyPaste/MacCopyPaste/Classes/ImageDocument.cs
+++ b/MacCopyPaste/MacCopyPaste/Classes/ImageDocument.cs
@@ -89,11 +89,13 @@ namespace MacCopyPaste
 			ok = pasteboard.CanReadObjectForClasses (classArray2, null);
 			if (ok) {
 				// Read the image off of the pasteboard
-				NSObject [] objectsToPaste = pasteboard.ReadObjectsForClasses (classArray2, null);
-                	if (objectsToPaste.Length > 0)
-                	{
-                    		ImageInfo info = (ImageInfo)objectsToPaste[0];
-                	}
+				NSObject[] objectsToPaste = pasteboard.ReadObjectsForClasses(classArray2, null);
+				if (objectsToPaste.Length > 0)
+				{
+					ImageInfo info = (ImageInfo)objectsToPaste[0];
+
+				}
+
 
 
 			}

--- a/MacCopyPaste/MacCopyPaste/Classes/ImageInfo.cs
+++ b/MacCopyPaste/MacCopyPaste/Classes/ImageInfo.cs
@@ -34,11 +34,11 @@ namespace MacCopyPaste
 			var type = decoder.DecodeObject("imageType") as NSString;
 
 			// Save data
-            if (name!= null && type != null)
-            {
-                Name = name.ToString();
-                ImageType = type.ToString();
-            }
+            		if (name!= null && type != null)
+            		{
+                		Name = name.ToString();
+                		ImageType = type.ToString();
+            		}
 		}
 		#endregion
 
@@ -46,11 +46,11 @@ namespace MacCopyPaste
 		[Export ("encodeWithCoder:")]
 		public void EncodeTo (NSCoder encoder)
 		{
-            if (Name != null && ImageType != null)
-            {
-                encoder.Encode(new NSString(Name), "name");
-                encoder.Encode(new NSString(ImageType), "imageType");
-            }
+            		if (Name != null && ImageType != null)
+            		{
+                		encoder.Encode(new NSString(Name), "name");
+                		encoder.Encode(new NSString(ImageType), "imageType");
+            		}
 		}
 
 		[Export ("writableTypesForPasteboard:")]

--- a/MacCopyPaste/MacCopyPaste/Classes/ImageInfo.cs
+++ b/MacCopyPaste/MacCopyPaste/Classes/ImageInfo.cs
@@ -34,7 +34,7 @@ namespace MacCopyPaste
 			var type = decoder.DecodeObject("imageType") as NSString;
 
 			// Save data
-            		if (name!= null && type != null)
+            		if (name != null && type != null)
             		{
                 		Name = name.ToString();
                 		ImageType = type.ToString();
@@ -46,11 +46,11 @@ namespace MacCopyPaste
 		[Export ("encodeWithCoder:")]
 		public void EncodeTo (NSCoder encoder)
 		{
-            		if (Name != null && ImageType != null)
-            		{
-                		encoder.Encode(new NSString(Name), "name");
-                		encoder.Encode(new NSString(ImageType), "imageType");
-            		}
+			if (Name != null && ImageType != null)
+			{
+				encoder.Encode(new NSString(Name), "name");
+				encoder.Encode(new NSString(ImageType), "imageType");
+			}
 		}
 
 		[Export ("writableTypesForPasteboard:")]

--- a/MacCopyPaste/MacCopyPaste/Classes/ImageInfo.cs
+++ b/MacCopyPaste/MacCopyPaste/Classes/ImageInfo.cs
@@ -34,8 +34,11 @@ namespace MacCopyPaste
 			var type = decoder.DecodeObject("imageType") as NSString;
 
 			// Save data
-			Name = name.ToString();
-			ImageType = type.ToString ();
+            if (name!= null && type != null)
+            {
+                Name = name.ToString();
+                ImageType = type.ToString();
+            }
 		}
 		#endregion
 
@@ -43,9 +46,11 @@ namespace MacCopyPaste
 		[Export ("encodeWithCoder:")]
 		public void EncodeTo (NSCoder encoder)
 		{
-			// Encode data
-			encoder.Encode(new NSString(Name),"name");
-			encoder.Encode(new NSString(ImageType),"imageType");
+            if (Name != null && ImageType != null)
+            {
+                encoder.Encode(new NSString(Name), "name");
+                encoder.Encode(new NSString(ImageType), "imageType");
+            }
 		}
 
 		[Export ("writableTypesForPasteboard:")]


### PR DESCRIPTION
[QAXM] fix bug https://bugzilla.xamarin.com/show_bug.cgi?id=45890

Fixed crash on copy button.
Steps to reproduce:
1. Launch app, select image.
2. Click copy button, this will update pasteboard.
3. Close application & relaunch it.
4. Click on paste button. This will paste earlier copied image.
5. Click on copy button. App was crashing here.