### PR TITLE
Fix OpenGLViewSample

### DIFF
--- a/OpenGLViewSample/OpenGLViewSample/AppDelegate.cs
+++ b/OpenGLViewSample/OpenGLViewSample/AppDelegate.cs
@@ -22,7 +22,7 @@ namespace OpenGLViewSample
 		{
 			mainWindowController = new MainWindowController ();
 			view = new GLView (mainWindowController.Window.Frame, new NSOpenGLPixelFormat (new object [] {
-										NSOpenGLPixelFormatAttribute.FullScreen,
+										NSOpenGLPixelFormatAttribute.Accelerated,
 										NSOpenGLPixelFormatAttribute.MinimumPolicy				
 			}));
 			


### PR DESCRIPTION
[QAXM] fix bug https://bugzilla.xamarin.com/show_bug.cgi?id=57657

Fullscreen is depreciated so used .Accelerated.