### PR TITLE
Fixed debug configuration for QTRecorder

### DIFF
--- a/QTRecorder/QTRecorder.csproj
+++ b/QTRecorder/QTRecorder.csproj
@@ -22,6 +22,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
+    <MonoBundlingExtraArgs>--registrar=dynamic</MonoBundlingExtraArgs>
     <UseSGen>false</UseSGen>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">

--- a/QTRecorder/README.md
+++ b/QTRecorder/README.md
@@ -9,3 +9,14 @@ This applications shows how to use various QuickTime features:
 * Apply CoreImage effects to the video source.
 * Use Cocoa drawers.
 * Use Cocoa Key/Value bindings to the UI and a document-based interface.
+
+
+---
+###### Attention
+
+
+The partial static registrar isn't compatible with QTKit.
+
+The partial static registrar assumes everything in Xamarin.Mac.dll has been registered properly, but we skip QTKit-based types, because we don't have headers for those.
+
+So you should add `<MonoBundlingExtraArgs>--registrar=dynamic</MonoBundlingExtraArgs>` to all configurations.

--- a/QTRecorder/README.md
+++ b/QTRecorder/README.md
@@ -15,8 +15,12 @@ This applications shows how to use various QuickTime features:
 ###### Attention
 
 
-The partial static registrar isn't compatible with QTKit.
+Apple has [deprecated](https://developer.apple.com/library/content/technotes/tn2300/_index.html#//apple_ref/doc/uid/DTS40012852-CH1-XCODE) QTKit and no longer ships header files needed by the static registrar.
 
-The partial static registrar assumes everything in Xamarin.Mac.dll has been registered properly, but we skip QTKit-based types, because we don't have headers for those.
+This can be worked around by adding:
 
-So you should add `<MonoBundlingExtraArgs>--registrar=dynamic</MonoBundlingExtraArgs>` to all configurations.
+`<MonoBundlingExtraArgs>--registrar=dynamic</MonoBundlingExtraArgs>`
+
+to the MMP arguments of all projects still using QTKit.
+
+More information about the registrar can be found [here](https://developer.xamarin.com/guides/mac/under-the-hood/registrar/).


### PR DESCRIPTION
  Added `MonoBundlingExtraArgs` to debug configuration and updated `Readme` file
  
  