### PR TITLE
Fix mac-samples bug #48 CoreWLANWirelessManager fails to build with Xamarin.Mac 4.3.0

### DIFF
--- a/CoreWLANWirelessManager/CoreWLANWirelessManager/Info.plist
+++ b/CoreWLANWirelessManager/CoreWLANWirelessManager/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.6</string>
+	<string>10.7</string>
 	<key>NSMainNibFile</key>
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>


### PR DESCRIPTION
Fixes https://github.com/xamarin/mac-samples/issues/48