### PR TITLE
[HeartRateMonitor] Fix events race condition. Fixes #60696

### DIFF
--- a/HeartRateMonitor/MainWindowController.cs
+++ b/HeartRateMonitor/MainWindowController.cs
@@ -210,8 +210,6 @@ namespace Xamarin.HeartMonitor
 				deviceTableView.ReloadData ();
 				DisconnectMonitor ();
 			};
-
-			HeartRateMonitor.ScanForHeartRateMonitors (manager);
 		}
 
 		void OnCentralManagerUpdatedState (object sender, EventArgs e)
@@ -220,7 +218,10 @@ namespace Xamarin.HeartMonitor
 
 			switch (manager.State) {
 			case CBCentralManagerState.PoweredOn:
-				connectButton.Enabled = true;
+				if (!connectButton.Enabled) {
+					HeartRateMonitor.ScanForHeartRateMonitors(manager);
+					connectButton.Enabled = true;
+				}
 				return;
 			case CBCentralManagerState.Unsupported:
 				message = "The platform or hardware does not support Bluetooth Low Energy.";


### PR DESCRIPTION
The sample in High Sierra is racy  when registering to the
CBCentralManager events. The scan method needs to be called once we are
sure that the manager is on and ready, else, events wont be correctly
dealt with.

Bugzilla: https://bugzilla.xamarin.com/show_bug.cgi?id=60696