### PR TITLE
[XM] fixed native ref linking and warning for the "Markdown" project

### DIFF
--- a/MarkdownViewer/Markdown.csproj
+++ b/MarkdownViewer/Markdown.csproj
@@ -33,13 +33,23 @@
     <PackageSigningKey>Developer ID Installer</PackageSigningKey>
     <CustomCommands>
       <CustomCommands>
-        <Command type="BeforeBuild" command="make -C &quot;${ProjectDir}/sundown/&quot;" />
-        <Command type="BeforeBuild" command="cp &quot;${ProjectDir}/sundown/libsundown.dylib&quot; &quot;${ProjectDir}/Resources&quot;" />
-        <Command type="AfterClean" command="rm -f &quot;${ProjectDir}/Resources/libsundown.dylib&quot;" />
+        <Command>
+          <type>BeforeBuild</type>
+          <command>make -C "${ProjectDir}/sundown/"</command>
+        </Command>
+        <Command>
+          <type>BeforeBuild</type>
+          <command>cp "${ProjectDir}/sundown/libsundown.dylib" "${ProjectDir}/Resources"</command>
+        </Command>
+        <Command>
+          <type>AfterClean</type>
+          <command>rm -f "${ProjectDir}/Resources/libsundown.dylib"</command>
+        </Command>
       </CustomCommands>
     </CustomCommands>
     <UseRefCounting>false</UseRefCounting>
     <XamMacArch>i386</XamMacArch>
+    <AOTMode>None</AOTMode>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
     <DebugType>none</DebugType>
@@ -57,8 +67,25 @@
     <ConsolePause>False</ConsolePause>
     <PlatformTarget>x86</PlatformTarget>
     <PackageSigningKey>Developer ID Installer</PackageSigningKey>
+    <CustomCommands>
+      <CustomCommands>
+        <Command>
+          <type>BeforeBuild</type>
+          <command>make -C "${ProjectDir}/sundown/"</command>
+        </Command>
+        <Command>
+          <type>BeforeBuild</type>
+          <command>cp "${ProjectDir}/sundown/libsundown.dylib" "${ProjectDir}/Resources"</command>
+        </Command>
+        <Command>
+          <type>AfterClean</type>
+          <command>rm -f "${ProjectDir}/Resources/libsundown.dylib"</command>
+        </Command>
+      </CustomCommands>
+    </CustomCommands>
     <UseRefCounting>false</UseRefCounting>
     <XamMacArch>i386</XamMacArch>
+    <AOTMode>None</AOTMode>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'AppStore|x86' ">
     <DebugType>none</DebugType>
@@ -76,7 +103,24 @@
     <CreatePackage>True</CreatePackage>
     <EnablePackageSigning>True</EnablePackageSigning>
     <PlatformTarget>x86</PlatformTarget>
+    <CustomCommands>
+      <CustomCommands>
+        <Command>
+          <type>BeforeBuild</type>
+          <command>make -C "${ProjectDir}/sundown/"</command>
+        </Command>
+        <Command>
+          <type>BeforeBuild</type>
+          <command>cp "${ProjectDir}/sundown/libsundown.dylib" "${ProjectDir}/Resources"</command>
+        </Command>
+        <Command>
+          <type>AfterClean</type>
+          <command>rm -f "${ProjectDir}/Resources/libsundown.dylib"</command>
+        </Command>
+      </CustomCommands>
+    </CustomCommands>
     <UseRefCounting>false</UseRefCounting>
+    <AOTMode>None</AOTMode>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
@@ -109,6 +153,12 @@
     <BundleResource Include="Resources\Markdown.icns" />
     <BundleResource Include="Resources\Template.html" />
     <BundleResource Include="Resources\libsundown.dylib" />
+  </ItemGroup>
+  <ItemGroup>
+    <NativeReference Include="Resources\libsundown.dylib">
+      <Kind>Dynamic</Kind>
+      <SmartLink>False</SmartLink>
+    </NativeReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Mac\Xamarin.Mac.CSharp.targets" />
 </Project>

--- a/MarkdownViewer/Markdown.csproj
+++ b/MarkdownViewer/Markdown.csproj
@@ -31,22 +31,6 @@
     <ConsolePause>False</ConsolePause>
     <PlatformTarget>x86</PlatformTarget>
     <PackageSigningKey>Developer ID Installer</PackageSigningKey>
-    <CustomCommands>
-      <CustomCommands>
-        <Command>
-          <type>BeforeBuild</type>
-          <command>make -C "${ProjectDir}/sundown/"</command>
-        </Command>
-        <Command>
-          <type>BeforeBuild</type>
-          <command>cp "${ProjectDir}/sundown/libsundown.dylib" "${ProjectDir}/Resources"</command>
-        </Command>
-        <Command>
-          <type>AfterClean</type>
-          <command>rm -f "${ProjectDir}/Resources/libsundown.dylib"</command>
-        </Command>
-      </CustomCommands>
-    </CustomCommands>
     <UseRefCounting>false</UseRefCounting>
     <XamMacArch>i386</XamMacArch>
     <AOTMode>None</AOTMode>
@@ -67,22 +51,6 @@
     <ConsolePause>False</ConsolePause>
     <PlatformTarget>x86</PlatformTarget>
     <PackageSigningKey>Developer ID Installer</PackageSigningKey>
-    <CustomCommands>
-      <CustomCommands>
-        <Command>
-          <type>BeforeBuild</type>
-          <command>make -C "${ProjectDir}/sundown/"</command>
-        </Command>
-        <Command>
-          <type>BeforeBuild</type>
-          <command>cp "${ProjectDir}/sundown/libsundown.dylib" "${ProjectDir}/Resources"</command>
-        </Command>
-        <Command>
-          <type>AfterClean</type>
-          <command>rm -f "${ProjectDir}/Resources/libsundown.dylib"</command>
-        </Command>
-      </CustomCommands>
-    </CustomCommands>
     <UseRefCounting>false</UseRefCounting>
     <XamMacArch>i386</XamMacArch>
     <AOTMode>None</AOTMode>
@@ -103,22 +71,6 @@
     <CreatePackage>True</CreatePackage>
     <EnablePackageSigning>True</EnablePackageSigning>
     <PlatformTarget>x86</PlatformTarget>
-    <CustomCommands>
-      <CustomCommands>
-        <Command>
-          <type>BeforeBuild</type>
-          <command>make -C "${ProjectDir}/sundown/"</command>
-        </Command>
-        <Command>
-          <type>BeforeBuild</type>
-          <command>cp "${ProjectDir}/sundown/libsundown.dylib" "${ProjectDir}/Resources"</command>
-        </Command>
-        <Command>
-          <type>AfterClean</type>
-          <command>rm -f "${ProjectDir}/Resources/libsundown.dylib"</command>
-        </Command>
-      </CustomCommands>
-    </CustomCommands>
     <UseRefCounting>false</UseRefCounting>
     <AOTMode>None</AOTMode>
   </PropertyGroup>
@@ -161,4 +113,5 @@
     </NativeReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Mac\Xamarin.Mac.CSharp.targets" />
+  <Import Project="MarkdownActions.targets" />
 </Project>

--- a/MarkdownViewer/MarkdownActions.targets
+++ b/MarkdownViewer/MarkdownActions.targets
@@ -1,0 +1,23 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+    <PropertyGroup>
+        <CleanDependsOn>
+            CleanResources;
+            $(CleanDependsOn);
+        </CleanDependsOn>
+
+        <BuildDependsOn>
+            PrepareResources;
+            $(BuildDependsOn);
+        </BuildDependsOn>
+    </PropertyGroup>
+    
+    <Target Name="CleanResources">
+      <Delete Files="Resources\libsundown.dylib" />
+    </Target>
+
+    <Target Name="PrepareResources">
+      <Exec Command="make -C sundown" />
+      <Copy SourceFiles="sundown\libsundown.dylib" DestinationFolder="Resources" />
+    </Target>
+</Project>


### PR DESCRIPTION
- added a`dylib` like a `NativeReference`
- added the same `CustomCommands` to the each `PropertyGroup` 

Before build the `dylib` added to the `Resources` folder and the project already linked with it.

Fixed: 
1. https://bugzilla.xamarin.com/show_bug.cgi?id=47052 (warning == `NativeReference`)
2. https://devdiv.visualstudio.com/DevDiv/_workitems/edit/579738?src=alerts&src-action=cta (additional custom commands)