### PR TITLE
[XM] removed `System.Drawing` usings; "MacCustomControl"

### DIFF
--- a/MacCustomControl/MacCustomControl/CustomGraphics/CustomControlsStyleKit.cs
+++ b/MacCustomControl/MacCustomControl/CustomGraphics/CustomControlsStyleKit.cs
@@ -10,7 +10,6 @@
 
 
 using System;
-using System.Drawing;
 using Foundation;
 using UIKit;
 using CoreGraphics;

--- a/MacCustomControl/MacCustomControl/UIKit/NSMutableParagraphStyle.cs
+++ b/MacCustomControl/MacCustomControl/UIKit/NSMutableParagraphStyle.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Drawing;
 using Foundation;
 using AppKit;
 using CoreGraphics;

--- a/MacCustomControl/MacCustomControl/UIKit/NSShadow.cs
+++ b/MacCustomControl/MacCustomControl/UIKit/NSShadow.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Drawing;
 using Foundation;
 using AppKit;
 using CoreGraphics;

--- a/MacCustomControl/MacCustomControl/UIKit/UIBezierPath.cs
+++ b/MacCustomControl/MacCustomControl/UIKit/UIBezierPath.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Drawing;
 using Foundation;
 using AppKit;
 using CoreGraphics;

--- a/MacCustomControl/MacCustomControl/UIKit/UIColor.cs
+++ b/MacCustomControl/MacCustomControl/UIKit/UIColor.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Drawing;
 using Foundation;
 using AppKit;
 using CoreGraphics;

--- a/MacCustomControl/MacCustomControl/UIKit/UIFont.cs
+++ b/MacCustomControl/MacCustomControl/UIKit/UIFont.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Drawing;
 using Foundation;
 using AppKit;
 using CoreGraphics;

--- a/MacCustomControl/MacCustomControl/UIKit/UIGraphics.cs
+++ b/MacCustomControl/MacCustomControl/UIKit/UIGraphics.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Drawing;
 using Foundation;
 using AppKit;
 using CoreGraphics;

--- a/MacCustomControl/MacCustomControl/UIKit/UIGraphicsContext.cs
+++ b/MacCustomControl/MacCustomControl/UIKit/UIGraphicsContext.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Drawing;
 using Foundation;
 using AppKit;
 using CoreGraphics;

--- a/MacCustomControl/MacCustomControl/UIKit/UIImage.cs
+++ b/MacCustomControl/MacCustomControl/UIKit/UIImage.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Drawing;
 using Foundation;
 using AppKit;
 using CoreGraphics;

--- a/MacCustomControl/MacCustomControl/UIKit/UIStringDrawing.cs
+++ b/MacCustomControl/MacCustomControl/UIKit/UIStringDrawing.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Drawing;
 using Foundation;
 using AppKit;
 using CoreGraphics;


### PR DESCRIPTION
- removed all `System.Drawing` usings because the app is not built successfully in Full mode