### PR TITLE
INSCoding => INSSecureCoding to fix runtime error on paste.

### DIFF
--- a/MacCopyPaste/MacCopyPaste/Classes/ImageInfo.cs
+++ b/MacCopyPaste/MacCopyPaste/Classes/ImageInfo.cs
@@ -6,7 +6,7 @@ using Foundation;
 namespace MacCopyPaste
 {
 	[Register("ImageInfo")]
-	public class ImageInfo : NSObject, INSCoding, INSPasteboardWriting, INSPasteboardReading
+    public class ImageInfo : NSObject, INSSecureCoding, INSPasteboardWriting, INSPasteboardReading
 	{
 		#region Computed Properties
 		[Export("name")]
@@ -14,6 +14,9 @@ namespace MacCopyPaste
 
 		[Export("imageType")]
 		public string ImageType { get; set; }
+
+        [Export("supportsSecureCoding")]
+        public static bool SupportsSecureCoding => true;
 		#endregion
 
 		#region Constructors


### PR DESCRIPTION
- Fixes https://github.com/xamarin/mac-samples/issues/93
- Fixes runtime error:

```shell
frame #12: 0x000000010bd16f93 MacCopyPaste`::xamarin_process_nsexception_using_mode(ns_exception=name: "NSInvalidUnarchiveOperationException" - reason: "This decoder will only decode classes that adopt NSSecureCoding. Class 'ImageInfo' does not adopt it.", throwManagedAsDefault=false) at runtime.m:2207
