### PR TITLE
Updated min system version

### DIFF
--- a/AnimatedClock/Info.plist
+++ b/AnimatedClock/Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.7</string>
+	<string>10.9</string>
 	<key>NSMainNibFile</key>
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>

--- a/AnimatingViews/Info.plist
+++ b/AnimatingViews/Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.7</string>
+	<string>10.9</string>
 	<key>NSMainNibFile</key>
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>

--- a/AzureTodoMac/AzureTodoMac/Info.plist
+++ b/AzureTodoMac/AzureTodoMac/Info.plist
@@ -23,7 +23,7 @@
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.8</string>
+	<string>10.9</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>craigdunn</string>
 	<key>NSMainNibFile</key>

--- a/ButtonMadness/Info.plist
+++ b/ButtonMadness/Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.7</string>
+	<string>10.9</string>
 	<key>NSMainNibFile</key>
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>

--- a/CAQuartzComposition/Info.plist
+++ b/CAQuartzComposition/Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.7</string>
+	<string>10.9</string>
 	<key>NSMainNibFile</key>
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>

--- a/CFNetwork/Info.plist
+++ b/CFNetwork/Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.7</string>
+	<string>10.9</string>
 	<key>NSMainNibFile</key>
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>

--- a/CoreAnimationBook/BackgroundFilteredView/Info.plist
+++ b/CoreAnimationBook/BackgroundFilteredView/Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.7</string>
+	<string>10.9</string>
 	<key>NSMainNibFile</key>
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>

--- a/CoreAnimationBook/CustomAnimationTiming/Info.plist
+++ b/CoreAnimationBook/CustomAnimationTiming/Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.7</string>
+	<string>10.9</string>
 	<key>NSMainNibFile</key>
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>

--- a/CoreAnimationBook/CustomizeAnimation/Info.plist
+++ b/CoreAnimationBook/CustomizeAnimation/Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.7</string>
+	<string>10.9</string>
 	<key>NSMainNibFile</key>
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>

--- a/CoreAnimationBook/CustomizeAnimation2/Info.plist
+++ b/CoreAnimationBook/CustomizeAnimation2/Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.7</string>
+	<string>10.9</string>
 	<key>NSMainNibFile</key>
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>

--- a/CoreAnimationBook/FilteredView/Info.plist
+++ b/CoreAnimationBook/FilteredView/Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.7</string>
+	<string>10.9</string>
 	<key>NSMainNibFile</key>
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>

--- a/CoreAnimationBook/GroupAnimation/Info.plist
+++ b/CoreAnimationBook/GroupAnimation/Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.7</string>
+	<string>10.9</string>
 	<key>NSMainNibFile</key>
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>

--- a/CoreAnimationBook/KeyFrameMoveAView/Info.plist
+++ b/CoreAnimationBook/KeyFrameMoveAView/Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.7</string>
+	<string>10.9</string>
 	<key>NSMainNibFile</key>
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>

--- a/CoreAnimationBook/LayerBackedControls/Info.plist
+++ b/CoreAnimationBook/LayerBackedControls/Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.7</string>
+	<string>10.9</string>
 	<key>NSMainNibFile</key>
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>

--- a/CoreAnimationBook/QCBackground/Info.plist
+++ b/CoreAnimationBook/QCBackground/Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.7</string>
+	<string>10.9</string>
 	<key>NSMainNibFile</key>
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>

--- a/CoreAnimationBook/TimedAnimation/Info.plist
+++ b/CoreAnimationBook/TimedAnimation/Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.7</string>
+	<string>10.9</string>
 	<key>NSMainNibFile</key>
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>

--- a/CoreTextArcMonoMac/Info.plist
+++ b/CoreTextArcMonoMac/Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.7</string>
+	<string>10.9</string>
 	<key>NSMainNibFile</key>
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>
@@ -18,26 +18,26 @@
 	<string></string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
-        <key>CFBundleDocumentTypes</key>
-        <array>
-                <dict>
-                        <key>CFBundleTypeExtensions</key>
-                        <array>
-                                <string>????</string>
-                        </array>
-                        <key>CFBundleTypeIconFile</key>
-                        <string></string>
-                        <key>CFBundleTypeName</key>
-                        <string>DocumentType</string>
-                        <key>CFBundleTypeOSTypes</key>
-                        <array>
-                                <string>????</string>
-                        </array>
-                        <key>CFBundleTypeRole</key>
-                        <string>Editor</string>
-                        <key>NSDocumentClass</key>
-                        <string>MyDocument</string>
-                </dict>
-        </array>
+	<key>CFBundleDocumentTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeExtensions</key>
+			<array>
+				<string>????</string>
+			</array>
+			<key>CFBundleTypeIconFile</key>
+			<string></string>
+			<key>CFBundleTypeName</key>
+			<string>DocumentType</string>
+			<key>CFBundleTypeOSTypes</key>
+			<array>
+				<string>????</string>
+			</array>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>NSDocumentClass</key>
+			<string>MyDocument</string>
+		</dict>
+	</array>
 </dict>
 </plist>

--- a/CoreWLANWirelessManager/CoreWLANWirelessManager/Info.plist
+++ b/CoreWLANWirelessManager/CoreWLANWirelessManager/Info.plist
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
@@ -11,7 +11,7 @@
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.7</string>
+	<string>10.9</string>
 	<key>NSMainNibFile</key>
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>

--- a/CustomFont/CustomFont/Info.plist
+++ b/CustomFont/CustomFont/Info.plist
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
@@ -23,7 +23,7 @@
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.8</string>
+	<string>10.9</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>donblas</string>
 	<key>NSMainNibFile</key>

--- a/DatePicker/Info.plist
+++ b/DatePicker/Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.7</string>
+	<string>10.9</string>
 	<key>NSMainNibFile</key>
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>

--- a/DockAppIcon/Info.plist
+++ b/DockAppIcon/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.7</string>
+	<string>10.9</string>
 	<key>NSMainNibFile</key>
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>

--- a/DocumentSample/Info.plist
+++ b/DocumentSample/Info.plist
@@ -34,7 +34,7 @@
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.7</string>
+	<string>10.9</string>
 	<key>NSMainNibFile</key>
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>

--- a/DragAndDropExample/DragAndDropExample/Info.plist
+++ b/DragAndDropExample/DragAndDropExample/Info.plist
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
@@ -23,7 +23,7 @@
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.8</string>
+	<string>10.9</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>donblas</string>
 	<key>NSMainNibFile</key>

--- a/DrawerMadness/DrawerMadness/Info.plist
+++ b/DrawerMadness/DrawerMadness/Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.7</string>
+	<string>10.9</string>
 	<key>NSMainNibFile</key>
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>

--- a/FSEvents/Info.plist
+++ b/FSEvents/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.7</string>
+	<string>10.9</string>
 	<key>NSMainNibFile</key>
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>

--- a/Fire/Info.plist
+++ b/Fire/Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.7</string>
+	<string>10.9</string>
 	<key>NSMainNibFile</key>
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>

--- a/GLFullScreen/GLFullScreen/Info.plist
+++ b/GLFullScreen/GLFullScreen/Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.7</string>
+	<string>10.9</string>
 	<key>NSMainNibFile</key>
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>

--- a/GLSLShader/Info.plist
+++ b/GLSLShader/Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.7</string>
+	<string>10.9</string>
 	<key>NSMainNibFile</key>
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>

--- a/GlossyClock/Info.plist
+++ b/GlossyClock/Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.7</string>
+	<string>10.9</string>
 	<key>NSMainNibFile</key>
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>

--- a/HeartRateMonitor/Info.plist
+++ b/HeartRateMonitor/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.7</string>
+	<string>10.9</string>
 	<key>NSMainNibFile</key>
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>

--- a/ImageKitDemoStep1/Info.plist
+++ b/ImageKitDemoStep1/Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.7</string>
+	<string>10.9</string>
 	<key>NSMainNibFile</key>
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>

--- a/MacDatabase/MacDatabase/Info.plist
+++ b/MacDatabase/MacDatabase/Info.plist
@@ -23,7 +23,7 @@
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.8</string>
+	<string>10.9</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>kmullins</string>
 	<key>NSMainNibFile</key>

--- a/MacDatabinding-XIBs/MacDatabinding/Info.plist
+++ b/MacDatabinding-XIBs/MacDatabinding/Info.plist
@@ -23,7 +23,7 @@
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.8</string>
+	<string>10.9</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>kmullins</string>
 	<key>NSMainNibFile</key>

--- a/MacOpenTK/MacOpenTK/Info.plist
+++ b/MacOpenTK/MacOpenTK/Info.plist
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
@@ -23,7 +23,7 @@
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.8</string>
+	<string>10.9</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>kmullins</string>
 	<key>NSMainNibFile</key>

--- a/MacXibless/MacXibless/Info.plist
+++ b/MacXibless/MacXibless/Info.plist
@@ -23,7 +23,7 @@
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.8</string>
+	<string>10.9</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>kmullins</string>
 	<key>NSMainNibFile</key>

--- a/MarkdownViewer/Info.plist
+++ b/MarkdownViewer/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.7</string>
+	<string>10.9</string>
 	<key>NSMainNibFile</key>
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>

--- a/MonoMacGameWindow/Info.plist
+++ b/MonoMacGameWindow/Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.7</string>
+	<string>10.9</string>
 	<key>NSMainNibFile</key>
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>

--- a/MouseTrackingExample/MouseTrackingExample/Info.plist
+++ b/MouseTrackingExample/MouseTrackingExample/Info.plist
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
@@ -11,7 +11,7 @@
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.8</string>
+	<string>10.9</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleInfoDictionaryVersion</key>
@@ -28,6 +28,5 @@
 	<string>MainMenu</string>
 	<key>XSAppIconAssets</key>
 	<string>Resources/Images.xcassets/AppIcons.appiconset</string>
-	
 </dict>
 </plist>

--- a/NSAlert/Info.plist
+++ b/NSAlert/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.7</string>
+	<string>10.9</string>
 	<key>NSMainNibFile</key>
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>

--- a/NSComboBoxTest/Info.plist
+++ b/NSComboBoxTest/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.7</string>
+	<string>10.9</string>
 	<key>NSMainNibFile</key>
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>

--- a/NSCustomView/NSCustomView/Info.plist
+++ b/NSCustomView/NSCustomView/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.7</string>
+	<string>10.9</string>
 	<key>NSMainNibFile</key>
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>

--- a/NSImageName/Info.plist
+++ b/NSImageName/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.7</string>
+	<string>10.9</string>
 	<key>NSMainNibFile</key>
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>

--- a/NSOutlineViewAndTableView/NSOutlineViewAndTableView/Info.plist
+++ b/NSOutlineViewAndTableView/NSOutlineViewAndTableView/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.7</string>
+	<string>10.9</string>
 	<key>NSMainNibFile</key>
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>

--- a/NSPortExample/MessageSender/MessageSender/Info.plist
+++ b/NSPortExample/MessageSender/MessageSender/Info.plist
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
@@ -23,7 +23,7 @@
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.8</string>
+	<string>10.9</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>donblas</string>
 	<key>NSMainNibFile</key>

--- a/NSTableViewBinding/Info.plist
+++ b/NSTableViewBinding/Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.7</string>
+	<string>10.9</string>
 	<key>NSMainNibFile</key>
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>

--- a/NSTextViewSample/Info.plist
+++ b/NSTextViewSample/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.7</string>
+	<string>10.9</string>
 	<key>NSMainNibFile</key>
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>

--- a/OpenGL-NeHe/NeHeLesson1/Info.plist
+++ b/OpenGL-NeHe/NeHeLesson1/Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.7</string>
+	<string>10.9</string>
 	<key>NSMainNibFile</key>
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>

--- a/OpenGL-NeHe/NeHeLesson13/Info.plist
+++ b/OpenGL-NeHe/NeHeLesson13/Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.7</string>
+	<string>10.9</string>
 	<key>NSMainNibFile</key>
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>

--- a/OpenGL-NeHe/NeHeLesson17/Info.plist
+++ b/OpenGL-NeHe/NeHeLesson17/Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.7</string>
+	<string>10.9</string>
 	<key>NSMainNibFile</key>
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>

--- a/OpenGL-NeHe/NeHeLesson2/Info.plist
+++ b/OpenGL-NeHe/NeHeLesson2/Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.7</string>
+	<string>10.9</string>
 	<key>NSMainNibFile</key>
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>

--- a/OpenGL-NeHe/NeHeLesson3/Info.plist
+++ b/OpenGL-NeHe/NeHeLesson3/Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.7</string>
+	<string>10.9</string>
 	<key>NSMainNibFile</key>
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>

--- a/OpenGL-NeHe/NeHeLesson4/Info.plist
+++ b/OpenGL-NeHe/NeHeLesson4/Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.7</string>
+	<string>10.9</string>
 	<key>NSMainNibFile</key>
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>

--- a/OpenGL-NeHe/NeHeLesson5/Info.plist
+++ b/OpenGL-NeHe/NeHeLesson5/Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.7</string>
+	<string>10.9</string>
 	<key>NSMainNibFile</key>
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>

--- a/OpenGL-NeHe/NeHeLesson6/Info.plist
+++ b/OpenGL-NeHe/NeHeLesson6/Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.7</string>
+	<string>10.9</string>
 	<key>NSMainNibFile</key>
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>

--- a/OpenGL-NeHe/NeHeLesson7/Info.plist
+++ b/OpenGL-NeHe/NeHeLesson7/Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.7</string>
+	<string>10.9</string>
 	<key>NSMainNibFile</key>
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>

--- a/OpenGL-NeHe/NeHeLesson8/Info.plist
+++ b/OpenGL-NeHe/NeHeLesson8/Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.7</string>
+	<string>10.9</string>
 	<key>NSMainNibFile</key>
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>

--- a/OpenGL-NeHe/NeHeLesson9/Info.plist
+++ b/OpenGL-NeHe/NeHeLesson9/Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.7</string>
+	<string>10.9</string>
 	<key>NSMainNibFile</key>
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>

--- a/OpenGLLayer/Info.plist
+++ b/OpenGLLayer/Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.7</string>
+	<string>10.9</string>
 	<key>NSMainNibFile</key>
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>

--- a/OpenGLViewSample/OpenGLViewSample/Info.plist
+++ b/OpenGLViewSample/OpenGLViewSample/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.7</string>
+	<string>10.9</string>
 	<key>NSMainNibFile</key>
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>

--- a/OutlineView/OutlineView/Info.plist
+++ b/OutlineView/OutlineView/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.7</string>
+	<string>10.9</string>
 	<key>NSMainNibFile</key>
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>

--- a/PopupBindings/Info.plist
+++ b/PopupBindings/Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.7</string>
+	<string>10.9</string>
 	<key>NSMainNibFile</key>
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>

--- a/PredicateEditorSample/Info.plist
+++ b/PredicateEditorSample/Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.7</string>
+	<string>10.9</string>
 	<key>NSMainNibFile</key>
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>

--- a/ProgressBarExample/ProgressBarExample/Info.plist
+++ b/ProgressBarExample/ProgressBarExample/Info.plist
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
@@ -23,7 +23,7 @@
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.8</string>
+	<string>10.9</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>donblas</string>
 	<key>NSMainNibFile</key>

--- a/QTRecorder/Info.plist
+++ b/QTRecorder/Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.7</string>
+	<string>10.9</string>
 	<key>NSMainNibFile</key>
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>

--- a/ReactiveUIExample/ReactiveUIExample/Info.plist
+++ b/ReactiveUIExample/ReactiveUIExample/Info.plist
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
@@ -23,7 +23,7 @@
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.8</string>
+	<string>10.9</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>donblas</string>
 	<key>NSMainNibFile</key>

--- a/RoundedTransparentWindow/Info.plist
+++ b/RoundedTransparentWindow/Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.7</string>
+	<string>10.9</string>
 	<key>NSMainNibFile</key>
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>

--- a/Rulers/Info.plist
+++ b/Rulers/Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.7</string>
+	<string>10.9</string>
 	<key>NSMainNibFile</key>
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>

--- a/SCNetworkReachability/Info.plist
+++ b/SCNetworkReachability/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.7</string>
+	<string>10.9</string>
 	<key>NSMainNibFile</key>
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>

--- a/SceneKitViewer/Info.plist
+++ b/SceneKitViewer/Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.8</string>
+	<string>10.9</string>
 	<key>NSMainNibFile</key>
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>

--- a/SearchField/Info.plist
+++ b/SearchField/Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.7</string>
+	<string>10.9</string>
 	<key>NSMainNibFile</key>
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>

--- a/SkinnableApp/Info.plist
+++ b/SkinnableApp/Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.7</string>
+	<string>10.9</string>
 	<key>NSMainNibFile</key>
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>

--- a/StillMotion/StillMotion/Info.plist
+++ b/StillMotion/StillMotion/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.7</string>
+	<string>10.9</string>
 	<key>NSMainNibFile</key>
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>

--- a/UserNotificationExample/UserNotificationExample/Info.plist
+++ b/UserNotificationExample/UserNotificationExample/Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.7</string>
+	<string>10.9</string>
 	<key>NSMainNibFile</key>
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>

--- a/VillainTracker/Info.plist
+++ b/VillainTracker/Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.7</string>
+	<string>10.9</string>
 	<key>NSMainNibFile</key>
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>

--- a/WhereIsMyMac/Info.plist
+++ b/WhereIsMyMac/Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.7</string>
+	<string>10.9</string>
 	<key>NSMainNibFile</key>
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>


### PR DESCRIPTION
Starting from `XM 5.5.1.192` we started getting an error like this: 
```
MMP : error MM0073: Xamarin.Mac 5.5.1 does not support a deployment target of 10.7 for macOS (the minimum is 10.9).
```
I've updated all samples that were 10.8 or 10.7 to 10.9.
