### PR TITLE
Fix InvalidOperationException in MacWindows sample 

### DIFF
--- a/MacWindows/MacWindows/MasterWindowController.cs
+++ b/MacWindows/MacWindows/MasterWindowController.cs
@@ -7,8 +7,7 @@ using AppKit;
 
 namespace MacWindows
 {
-	public partial class MasterWindowController : NSWindowController
-	{
+	public partial class MasterWindowController : NSWindowController, INSWindowDelegate {
 		public MasterWindowController (IntPtr handle) : base (handle)
 		{
 		}
@@ -16,15 +15,19 @@ namespace MacWindows
 		public override void WindowDidLoad ()
 		{
 			base.WindowDidLoad ();
+			Window.Delegate = this;
+		}
 
-			Window.DidResize += (sender, e) => {
-				// Do something as the window is being live resized
-			};
+		[Export ("windowDidResize:")]
+		public void DidResize (NSNotification notification)
+		{
+			throw new System.NotImplementedException ();
+		}
 
-			Window.DidEndLiveResize += (sender, e) => {
-				// Do something after the user's finished resizing
-				// the window
-			};
+		[Export ("windowDidEndLiveResize:")]
+		public void DidEndLiveResize (NSNotification notification)
+		{
+			throw new System.NotImplementedException ();
 		}
 	}
 }

--- a/MacWindows/MacWindows/MasterWindowController.cs
+++ b/MacWindows/MacWindows/MasterWindowController.cs
@@ -21,13 +21,14 @@ namespace MacWindows
 		[Export ("windowDidResize:")]
 		public void DidResize (NSNotification notification)
 		{
-			throw new System.NotImplementedException ();
+			// Do something as the window is being live resized
 		}
 
 		[Export ("windowDidEndLiveResize:")]
 		public void DidEndLiveResize (NSNotification notification)
 		{
-			throw new System.NotImplementedException ();
+			// Do something after the user's finished resizing
+			// the window
 		}
 	}
 }


### PR DESCRIPTION
Fix https://github.com/xamarin/mac-samples/issues/123

Addresses one case of events + delegates colliding, in this case due to a newly added default delegate from Apple.

Detailed explanation here: https://github.com/xamarin/xamarin-macios/issues/7569