### PR TITLE
Fix InvalidOperationException in MacWindows sample

### DIFF
--- a/MacWindows/MacWindows/MasterWindowController.cs
+++ b/MacWindows/MacWindows/MasterWindowController.cs
@@ -7,8 +7,7 @@ using AppKit;
 
 namespace MacWindows
 {
-	public partial class MasterWindowController : NSWindowController
-	{
+	public partial class MasterWindowController : NSWindowController, INSWindowDelegate {
 		public MasterWindowController (IntPtr handle) : base (handle)
 		{
 		}
@@ -16,15 +15,19 @@ namespace MacWindows
 		public override void WindowDidLoad ()
 		{
 			base.WindowDidLoad ();
+			Window.Delegate = this;
+		}
 
-			Window.DidResize += (sender, e) => {
-				// Do something as the window is being live resized
-			};
+		[Export ("windowDidResize:")]
+		public void DidResize (NSNotification notification)
+		{
+			throw new System.NotImplementedException ();
+		}
 
-			Window.DidEndLiveResize += (sender, e) => {
-				// Do something after the user's finished resizing
-				// the window
-			};
+		[Export ("windowDidEndLiveResize:")]
+		public void DidEndLiveResize (NSNotification notification)
+		{
+			throw new System.NotImplementedException ();
 		}
 	}
 }

--- a/MacWindows/MacWindows/MasterWindowController.cs
+++ b/MacWindows/MacWindows/MasterWindowController.cs
@@ -21,13 +21,14 @@ namespace MacWindows
 		[Export ("windowDidResize:")]
 		public void DidResize (NSNotification notification)
 		{
-			throw new System.NotImplementedException ();
+			// Do something as the window is being live resized
 		}
 
 		[Export ("windowDidEndLiveResize:")]
 		public void DidEndLiveResize (NSNotification notification)
 		{
-			throw new System.NotImplementedException ();
+			// Do something after the user's finished resizing
+			// the window
 		}
 	}
 }

--- a/MacWindows/MacWindows/ViewController.cs
+++ b/MacWindows/MacWindows/ViewController.cs
@@ -5,7 +5,7 @@ using Foundation;
 
 namespace MacWindows
 {
-	public partial class ViewController : NSViewController
+	public partial class ViewController : NSViewController, INSWindowDelegate
 	{
 		#region Computed Properties
 		public override NSObject RepresentedObject {
@@ -45,6 +45,20 @@ namespace MacWindows
 
 		}
 
+		[Export ("windowWillClose:")]
+		public void WillClose (NSNotification notification)
+		{
+			// is the window dirty?
+			if (DocumentEdited) {
+				var alert = new NSAlert () {
+					AlertStyle = NSAlertStyle.Critical,
+					InformativeText = "We need to give the user the ability to save the document here...",
+					MessageText = "Save Document",
+				};
+				alert.RunModal ();
+			}
+		}
+
 		public override void ViewWillAppear ()
 		{
 			base.ViewWillAppear ();
@@ -52,17 +66,7 @@ namespace MacWindows
 			// Set Window Title
 			this.View.Window.Title = "untitled";
 
-			View.Window.WillClose += (sender, e) => {
-				// is the window dirty?
-				if (DocumentEdited) {
-					var alert = new NSAlert () {
-						AlertStyle = NSAlertStyle.Critical,
-						InformativeText = "We need to give the user the ability to save the document here...",
-						MessageText = "Save Document",
-					};
-					alert.RunModal ();
-				}
-			};
+			View.Window.Delegate = this;
 		}
 
 		public override void AwakeFromNib ()


### PR DESCRIPTION
Fix #123

Addresses one case of events + delegates colliding, in this case due to a newly added default delegate from Apple.

Detailed explanation here: xamarin/xamarin-macios#7569

I've validated that the sample builds + runs correctly with this fix :)