### PR TITLE
Fix ButtonMadness and MicroSamples/pdf samples

### DIFF
--- a/ButtonMadness/TestWindowController.cs
+++ b/ButtonMadness/TestWindowController.cs
@@ -158,17 +158,17 @@ namespace SamplesButtonMadness
 			nibBasedSegControl.SetMenu (buttonMenu, 0);
 
 			// add icons to each segment (applied to both nib-based and code-based)
-			NSImage segmentIcon1 = NSWorkspace.SharedWorkspace.IconForFileType(HFSTypeCode.ComputerIcon);
+			NSImage segmentIcon1 = NSWorkspace.SharedWorkspace.IconForFileType (HfsTypeCode.ComputerIcon);
 			segmentIcon1.Size = new CGSize(16, 16);
 			nibBasedSegControl.SetImage (segmentIcon1, 0);
 			codeBasedSegmentControl.SetImage (segmentIcon1, 0);
 			
-			NSImage segmentIcon2 = NSWorkspace.SharedWorkspace.IconForFileType (HFSTypeCode.DesktopIcon);
+			NSImage segmentIcon2 = NSWorkspace.SharedWorkspace.IconForFileType (HfsTypeCode.DesktopIcon);
 			segmentIcon2.Size = new CGSize (16, 16);
 			nibBasedSegControl.SetImage (segmentIcon2, 1);
 			codeBasedSegmentControl.SetImage (segmentIcon2, 1);
 			
-			NSImage segmentIcon3 = NSWorkspace.SharedWorkspace.IconForFileType (HFSTypeCode.FinderIcon);
+			NSImage segmentIcon3 = NSWorkspace.SharedWorkspace.IconForFileType (HfsTypeCode.FinderIcon);
 			segmentIcon3.Size = new CGSize (16, 16);
 			nibBasedSegControl.SetImage (segmentIcon3, 2);
 			codeBasedSegmentControl.SetImage (segmentIcon3, 2);

--- a/MicroSamples/pdf/pdf.csproj
+++ b/MicroSamples/pdf/pdf.csproj
@@ -48,20 +48,6 @@
     <Reference Include="Xamarin.Mac" />
   </ItemGroup>
   <ItemGroup>
-    <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Contents.json" />
-    <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\AppIcon-128.png" />
-    <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\AppIcon-128%402x.png" />
-    <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\AppIcon-16.png" />
-    <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\AppIcon-16%402x.png" />
-    <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\AppIcon-256.png" />
-    <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\AppIcon-256%402x.png" />
-    <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\AppIcon-32.png" />
-    <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\AppIcon-32%402x.png" />
-    <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\AppIcon-512.png" />
-    <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\AppIcon-512%402x.png" />
-    <ImageAsset Include="Assets.xcassets\Contents.json" />
-  </ItemGroup>
-  <ItemGroup>
     <Folder Include="Resources\" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Fixes: https://github.com/xamarin/mac-samples/issues/132

ButtonMadness had a casing related typo in its `HfsTypeCode` enum usage.
MicroSamples/pdf does not contain any app icon or other Assets.xcassets
content, so the invalid `<ImageAsset/>` elements have been removed.