### PR TITLE
[DragAndDropExample] Set NSDraggingItem.DraggingFrame before starting dragging. Fixes #135.

### DIFF
--- a/DragAndDropExample/DragAndDropExample/Classes/SourceView.cs
+++ b/DragAndDropExample/DragAndDropExample/Classes/SourceView.cs
@@ -43,6 +43,9 @@ namespace DragAndDropExample
 			var text = new NSDraggingItem ((NSString)"Hello World");
 			var images = new NSDraggingItem (homeImage);
 
+			text.DraggingFrame = Bounds;
+			images.DraggingFrame = Bounds;
+
 			// Inform the OS that the drag has started and that it contains the two elements
 			// that we created above
 			BeginDraggingSession (new [] { text, images }, theEvent, this);


### PR DESCRIPTION
Set NSDraggingItem.DraggingFrame before starting dragging, otherwise the app
will crash:

    *** Terminating app due to uncaught exception 'NSRangeException', reason: 'NSDraggingItem.draggingFrame cannot be set to a zero size {{0, 0}, {0, 0}}'
    *** First throw call stack:
    (
    	0   CoreFoundation                      0x00007fff37b60b57 __exceptionPreprocess + 250
    	1   libobjc.A.dylib                     0x00007fff709ec5bf objc_exception_throw + 48
    	2   AppKit                              0x00007fff357cf275 -[NSDraggingItem draggingFrame] + 0
    	3   AppKit                              0x00007fff3562676e __61-[NSView(NSDrag) beginDraggingSessionWithItems:event:source:]_block_invoke + 175
    	4   CoreFoundation                      0x00007fff37ad8527 __NSARRAY_IS_CALLING_OUT_TO_A_BLOCK__ + 7
    	5   CoreFoundation                      0x00007fff37b85678 __53-[__NSArrayI enumerateObjectsWithOptions:usingBlock:]_block_invoke + 103
    	6   libdispatch.dylib                   0x00007fff71b3b68d _dispatch_client_callout2 + 8
    	7   libdispatch.dylib                   0x00007fff71b4bfd8 _dispatch_apply_invoke_and_wait + 157
    	8   libdispatch.dylib                   0x00007fff71b4bb36 dispatch_apply_f + 762
    	9   CoreFoundation                      0x00007fff37add6d6 -[__NSArrayI enumerateObjectsWithOptions:usingBlock:] + 328
    	10  AppKit                              0x00007fff35626610 -[NSView(NSDrag) beginDraggingSessionWithItems:event:source:] + 102

Fixes https://github.com/xamarin/mac-samples/issues/135.