### PR TITLE
[CoreWLANWirelessManager] Location Permission for BSSID Data. Fixes #129.

### DIFF
--- a/CoreWLANWirelessManager/CoreWLANWirelessManager/AppDelegate.cs
+++ b/CoreWLANWirelessManager/CoreWLANWirelessManager/AppDelegate.cs
@@ -3,6 +3,7 @@ using CoreGraphics;
 using Foundation;
 using AppKit;
 using ObjCRuntime;
+using CoreLocation;
 
 namespace CoreWLANWirelessManager
 {
@@ -12,6 +13,12 @@ namespace CoreWLANWirelessManager
 
 		public AppDelegate ()
 		{
+		}
+		
+		public override void WillFinishLaunching(NSNotification notification)
+		{
+			var manager = new CLLocationManager();
+			manager.RequestAlwaysAuthorization();
 		}
 
 		public override void DidFinishLaunching (NSNotification notification)


### PR DESCRIPTION
As part of MacOS Catalina changes, it is now required to have location access to see BSSID data.

Fixes #129.